### PR TITLE
Prefer SIM carrier name over network carrier

### DIFF
--- a/src/com/cyanogenmod/setupwizard/setup/ChooseDataSimPage.java
+++ b/src/com/cyanogenmod/setupwizard/setup/ChooseDataSimPage.java
@@ -396,7 +396,10 @@ public class ChooseDataSimPage extends SetupPage {
 
         private void updateCarrierText(SubscriptionInfo subInfoRecord) {
             if (mIsAttached) {
-                String name = mPhone.getNetworkOperatorName(subInfoRecord.getSubscriptionId());
+                String name = mPhone.getSimOperatorNameForSubscription(subInfoRecord.getSubscriptionId());
+                if (TextUtils.isEmpty(name)) {
+                    name = mPhone.getNetworkOperatorName(subInfoRecord.getSubscriptionId());
+                }
                 ServiceState serviceState = mServiceStates.get(subInfoRecord.getSimSlotIndex());
                 final int slot = subInfoRecord.getSimSlotIndex();
                 final View v = mRows.get(slot);

--- a/src/com/cyanogenmod/setupwizard/setup/MobileDataPage.java
+++ b/src/com/cyanogenmod/setupwizard/setup/MobileDataPage.java
@@ -237,7 +237,10 @@ public class MobileDataPage extends SetupPage {
         private void updateCarrierText() {
             if (mIsAttached) {
                 String name =
-                        mPhone.getNetworkOperatorName(SubscriptionManager.getDefaultDataSubId());
+                        mPhone.getSimOperatorNameForSubscription(SubscriptionManager.getDefaultDataSubId());
+                if (TextUtils.isEmpty(name)) {
+                    name = mPhone.getNetworkOperatorName(SubscriptionManager.getDefaultDataSubId());
+                }
                 if (TextUtils.isEmpty(name)) {
                     if (mServiceState != null && mServiceState.isEmergencyOnly()) {
                         name = getString(R.string.setup_mobile_data_emergency_only);


### PR DESCRIPTION
People generally identify their SIMs by the emitting carrier, not
the network they attach to. In roaming or MVNO scenarios, these
are likely not to be the same, leading to confusion in SIM selection.

Ref CYNGNOS-2496

Change-Id: I0ecd8e7511fd4229d6ce7629b1f97aa83a1a6254
